### PR TITLE
Allow sponsor image to be added to the bottom of each card

### DIFF
--- a/webroot/loadCards.js
+++ b/webroot/loadCards.js
@@ -57,7 +57,7 @@ function loadCards(data) {
               ${capacity}
               <i class="icon users"></i>
             </div>
-            <div class="ui ${room_color} basic  circular label">
+            <div class="ui ${room_color} basic circular label">
               ${room_sponsor}
             </div>
           </div>
@@ -126,8 +126,9 @@ function loadCards(data) {
               <i class="icon users"></i>
             </div>
             <div class="ui ${room_color} basic  circular label">
-              ${room_sponsor}
+               ${room_sponsor}
             </div>
+            <img src="${image}" class="ui fluid image"></img>
           </div>
         </div>
       `;


### PR DESCRIPTION
This adds the ability to include sponsorship images at the bottom the the talk cards. This is a prerequisite for Measurecamp Auckland next week.

Requires an additional: 'image' column in the Google Spreadsheet.